### PR TITLE
Limit memory usage when converting

### DIFF
--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -12,7 +12,6 @@ import os
 
 import numpy as np
 import pixelengine
-import psutil
 import softwarerendercontext
 import softwarerenderbackend
 
@@ -64,16 +63,18 @@ class MaxQueuePool(object):
     def __exit__(self, exception_type, exception_value, traceback):
         self.pool.__exit__(exception_type, exception_value, traceback)
 
+
 class WriteTiles(object):
 
     def __init__(
-        self, tile_width, tile_height, no_pyramid, file_type,
+        self, tile_width, tile_height, no_pyramid, file_type, max_workers,
         input_path, output_path
     ):
         self.tile_width = tile_width
         self.tile_height = tile_height
         self.no_pyramid = no_pyramid
         self.file_type = file_type
+        self.max_workers = max_workers
         self.input_path = input_path
         self.slide_directory = output_path
 
@@ -276,9 +277,7 @@ class WriteTiles(object):
                         source.save(destination)
 
             jobs = ()
-            with MaxQueuePool(
-                ThreadPoolExecutor, psutil.cpu_count(logical=False)
-            ) as pool:
+            with MaxQueuePool(ThreadPoolExecutor, self.max_workers) as pool:
                 while regions:
                     regions_ready = self.pixel_engine.waitAny(regions)
                     for region_index, region in enumerate(regions_ready):

--- a/isyntax2raw/cli/isyntax2raw.py
+++ b/isyntax2raw/cli/isyntax2raw.py
@@ -8,6 +8,7 @@
 # support@glencoesoftware.com.
 
 import click
+import psutil
 
 from .. import WriteTiles
 
@@ -19,26 +20,35 @@ def cli():
 
 @click.command()
 @click.option(
-    "--tile_width", default=512, type=int, help="tile width in pixels"
+    "--tile_width", default=512, type=int, show_default=True,
+    help="tile width in pixels"
 )
 @click.option(
-    "--tile_height", default=512, type=int, help="tile height in pixels"
+    "--tile_height", default=512, type=int, show_default=True,
+    help="tile height in pixels"
 )
 @click.option(
     "--no_pyramid", default=False, is_flag=True,
-    help="toggle subresolution writing",
+    help="disable subresolution writing"
 )
 @click.option(
-    "--file_type", default="tiff",
+    "--file_type", default="tiff", show_default=True,
     help="tile file extension (jpg, png, tiff)"
+)
+@click.option(
+    "--max_workers", default=psutil.cpu_count(logical=False), type=int,
+    show_default=True,
+    help="maximum number of tile workers that will run at one time",
 )
 @click.argument("input_path")
 @click.argument("output_path")
 def write_tiles(
-    tile_width, tile_height, no_pyramid, file_type, input_path, output_path
+    tile_width, tile_height, no_pyramid, file_type, max_workers, input_path,
+    output_path
 ):
     with WriteTiles(
-        tile_width, tile_height, no_pyramid, file_type, input_path, output_path
+        tile_width, tile_height, no_pyramid, file_type, max_workers,
+        input_path, output_path
     ) as wt:
         wt.write_metadata()
         wt.write_label_image()


### PR DESCRIPTION
This PR adds a bounded queue/pool which via delegation strictly
limits the number of in flight tasks and explicitly takes control of file
handle closure during writing.

In most cases on modern hardware with high frequency and multi-core CPUs
it will be faster to read and decompress data from the source than to
write it out to its destination.  This is true regardless of destination
file format or the presence of high performance storage.

A `ThreadPoolExecutor` in its standard form maintains an unbounded queue
for tasks.  Thus, `ThreadPoolExecutor.submit()` will never block and it
will happily take new tasks until system memory is exhausted.  That's
**very** bad for our use case as it rather quickly results in a very
large number tasks operating on 1.5MiB or more of data being
accumulated.  GiBs of system memory is then consumed.