### PR TITLE
Fix channel layout so that each channel is written to a separate file

### DIFF
--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -303,9 +303,11 @@ class WriteTiles(object):
             if self.file_type == "n5":
                 self.zarr_store = zarr.N5Store(tile_directory)
             self.zarr_group = zarr.group(store=self.zarr_store)
+            # important to explicitly set the channel chunk size to 1
+            # setting to None causes all 3 channels to be chunked together
             self.zarr_group.create_dataset(
                 str(resolution), shape=(3, height, width),
-                chunks=(None, self.tile_height, self.tile_width), dtype='B'
+                chunks=(1, self.tile_height, self.tile_width), dtype='B'
             )
         else:
             os.mkdir(tile_directory)


### PR DESCRIPTION
As discussed with @chris-allan, each channel is now written separately.  This is now consistent with bioformats2raw and allows us to simplify channel handling in raw2ometiff.

Converting ```1.isyntax``` with this change shows:

```
$ ls -hl pyramid.n5/5/0/0
total 632K
-rw-rw-r-- 1 melissa melissa 212K Apr 13 12:17 0
-rw-rw-r-- 1 melissa melissa 207K Apr 13 12:17 1
-rw-rw-r-- 1 melissa melissa 211K Apr 13 12:17 2
$ cat pyramid.n5/5/attributes.json 
{
    "blockSize": [
        512,
        512,
        1
    ],
    "compression": {
        "blocksize": 0,
        "clevel": 5,
        "cname": "lz4",
        "shuffle": 1,
        "type": "blosc"
    },
    "dataType": "uint8",
    "dimensions": [
        784,
        656,
        3
    ]
}
```

