### PR TITLE
Add explicit utf-8 encoding for OME-XML

### DIFF
--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -419,7 +419,7 @@ class WriteTiles(object):
         template = loader.import_("isyntax2raw.resources.ome_template")
         xml = template(xml_values).render()
         ome_xml_file = os.path.join(self.slide_directory, "METADATA.ome.xml")
-        with open(ome_xml_file, "w") as omexml:
+        with open(ome_xml_file, "w", encoding="utf-8") as omexml:
             omexml.write(xml)
 
     def get_size(self, dim_range):


### PR DESCRIPTION
isyntax2raw currently produces an OME-XML file using the default system encoding. On Windows, this results in an error when raw2ometiff attempts to parse the OME-XML file:

```
Exception in thread "main" picocli.CommandLine$ExecutionException: Error while calling command (com.glencoesoftware.pyramid.PyramidFromDirectoryWriter@61230f6a): java.lang.RuntimeException: loci.formats.FormatException: Could not parse OME-XML
        at picocli.CommandLine.executeUserObject(CommandLine.java:1792)
        at picocli.CommandLine.access$900(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2150)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2144)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
        at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:1968)
        at picocli.CommandLine.parseWithHandlers(CommandLine.java:2349)
        at picocli.CommandLine.parseWithHandler(CommandLine.java:2284)
        at picocli.CommandLine.call(CommandLine.java:2560)
        at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.main(PyramidFromDirectoryWriter.java:257)
Caused by: java.lang.RuntimeException: loci.formats.FormatException: Could not parse OME-XML
        at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.call(PyramidFromDirectoryWriter.java:297)
        at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.call(PyramidFromDirectoryWriter.java:87)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1783)
        ... 9 more
Caused by: loci.formats.FormatException: Could not parse OME-XML
        at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.initialize(PyramidFromDirectoryWriter.java:520)
        at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.call(PyramidFromDirectoryWriter.java:283)
        ... 11 more
Caused by: loci.common.services.ServiceException: ome.xml.model.enums.EnumerationException: '?m' not a supported value of 'class ome.xml.model.enums.UnitsLength'
        at loci.formats.services.OMEXMLServiceImpl.createRoot(OMEXMLServiceImpl.java:417)
        at loci.formats.services.OMEXMLServiceImpl.createOMEXMLMetadata(OMEXMLServiceImpl.java:373)
        at loci.formats.services.OMEXMLServiceImpl.createOMEXMLMetadata(OMEXMLServiceImpl.java:360)
        at com.glencoesoftware.pyramid.PyramidFromDirectoryWriter.initialize(PyramidFromDirectoryWriter.java:503)
        ... 12 more
Caused by: ome.xml.model.enums.EnumerationException: '?m' not a supported value of 'class ome.xml.model.enums.UnitsLength'
```

Explicitly stating utf-8 encoding for the OME-XML resolves this issue.
