### PR TITLE
Add --fill_color option to change the color of missing tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Use of a n5 (the default) or zarr `--file_type` will result in losslessly
 compressed output.  These are the only formats that are currently
 supported by the downstream `raw2ometiff`.
 
+## Background color
+
+Any missing tiles are filled with 0 by default, which displays as black.
+The fill value can be changed using the `--fill_color` option, which accepts
+a single integer between 0 and 255 inclusive.  Setting `--fill_color=255`
+will cause any missing tiles to display as white.
+
 ## Performance
 
 This package is __highly__ sensitive to underlying hardware as well as

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -80,7 +80,7 @@ class WriteTiles(object):
 
     def __init__(
         self, tile_width, tile_height, resolutions, file_type, max_workers,
-        batch_size, input_path, output_path
+        batch_size, input_path, output_path, fill_color
     ):
         self.tile_width = tile_width
         self.tile_height = tile_height
@@ -90,6 +90,7 @@ class WriteTiles(object):
         self.batch_size = batch_size
         self.input_path = input_path
         self.slide_directory = output_path
+        self.fill_color = fill_color
 
         os.makedirs(self.slide_directory, exist_ok=True)
 
@@ -576,7 +577,7 @@ class WriteTiles(object):
                         request_regions = image.source_view.request_regions
                     regions = request_regions(
                         patches[i:i + self.batch_size], envelopes, True,
-                        [0, 0, 0]
+                        [self.fill_color] * 3
                     )
                     while regions:
                         regions_ready = self.wait_any(regions)

--- a/isyntax2raw/cli/isyntax2raw.py
+++ b/isyntax2raw/cli/isyntax2raw.py
@@ -46,6 +46,11 @@ def cli():
     help="number of patches fed into the iSyntax SDK at one time"
 )
 @click.option(
+    "--fill_color", type=click.IntRange(min=0, max=255), default=0,
+    show_default=True,
+    help="background color for missing tiles (0-255)"
+)
+@click.option(
     "--debug", is_flag=True,
     help="enable debugging",
 )
@@ -53,7 +58,7 @@ def cli():
 @click.argument("output_path")
 def write_tiles(
     tile_width, tile_height, resolutions, file_type, max_workers, batch_size,
-    input_path, output_path, debug
+    input_path, output_path, fill_color, debug
 ):
     level = logging.INFO
     if debug:
@@ -65,7 +70,7 @@ def write_tiles(
     )
     with WriteTiles(
         tile_width, tile_height, resolutions, file_type, max_workers,
-        batch_size, input_path, output_path
+        batch_size, input_path, output_path, fill_color
     ) as wt:
         wt.write_metadata()
         wt.write_label_image()


### PR DESCRIPTION
Similar to https://github.com/glencoesoftware/bioformats2raw/pull/65, this should work as described in the readme.