### PR TITLE
Switch to Zarr only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,23 @@ Python tool that uses Philips' SDK to write slides in an intermediary raw format
 
 ## Requirements
 
+* Python 3.6+
 * Philips iSyntax SDK (https://openpathology.philips.com)
 
 The iSyntax SDK __must__ be downloaded separately from Philips and the
 relevant license agreement agreed to before any conversion can take place.
 
+As of version 0.4.0, which has a Python 3.6+ requirement, the supported
+iSyntax SDK versions and environments are as follows:
+
+* iSyntax SDK 1.2.1 (CentOS 7, Ubuntu 18.04, Windows 10 64-bit)
+* iSyntax SDK 2.0 (CentOS 8, Ubuntu 18.04, Windows 10 64-bit)
+
 ## Usage
 
 Basic usage is:
 
-    isyntax2raw write_tiles /path/to/input.isyntax /path/to/tile/directory
+    isyntax2raw write_tiles /path/to/input.isyntax /path/to/directory.zarr
 
 Please see `isyntax2raw write_tiles --help` for detailed information.
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Output tile width and height can optionally be specified; default values are
 detailed in `--help`.
 
 A directory structure containing the pyramid tiles at all resolutions and
-macro/label images will be created.  The default format is N5.  Additional
+macro/label images will be created.  The default format is Zarr.  Additional
 metadata is written to a JSON file.  Be mindful of available disk space, as
 larger .isyntax files can result in >20 GB of tiles.
 
-Use of a n5 (the default) or zarr `--file_type` will result in losslessly
-compressed output.  These are the only formats that are currently
-supported by the downstream `raw2ometiff`.
+Use of the Zarr file type will result in losslessly compressed output.  This
+is the only format currently supported by the downstream `raw2ometiff` (as of
+version 0.3.0).
 
 ## Background color
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 image: ubuntu1804
 
 install:
-  - sudo apt-get update
   - sudo apt-get install -y python3-setuptools python3-wheel twine
 
 build: off

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -80,16 +80,17 @@ class WriteTiles(object):
 
     def __init__(
         self, tile_width, tile_height, resolutions, max_workers,
-        batch_size, input_path, output_path, fill_color
+        batch_size, fill_color, nested, input_path, output_path
     ):
         self.tile_width = tile_width
         self.tile_height = tile_height
         self.resolutions = resolutions
         self.max_workers = max_workers
         self.batch_size = batch_size
+        self.fill_color = fill_color
+        self.nested = nested
         self.input_path = input_path
         self.slide_directory = output_path
-        self.fill_color = fill_color
 
         os.makedirs(os.path.join(self.slide_directory, "OME"), exist_ok=True)
 

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -483,6 +483,7 @@ class WriteTiles(object):
         if not self.nested:
             dimension_separator = '.'
         self.zarr_store = FSStore(
+            self.slide_directory,
             dimension_separator=dimension_separator,
             normalize_keys=True
         )

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -29,7 +29,7 @@ from kajiki import PackageLoader
 
 log = logging.getLogger(__name__)
 
-# version of the N5/Zarr layout
+# version of the Zarr layout
 LAYOUT_VERSION = 1
 
 
@@ -79,13 +79,12 @@ class MaxQueuePool(object):
 class WriteTiles(object):
 
     def __init__(
-        self, tile_width, tile_height, resolutions, file_type, max_workers,
+        self, tile_width, tile_height, resolutions, max_workers,
         batch_size, input_path, output_path, fill_color
     ):
         self.tile_width = tile_width
         self.tile_height = tile_height
         self.resolutions = resolutions
-        self.file_type = file_type
         self.max_workers = max_workers
         self.batch_size = batch_size
         self.input_path = input_path
@@ -475,11 +474,9 @@ class WriteTiles(object):
 
     def create_tile_directory(self, series, resolution, width, height):
         tile_directory = os.path.join(
-            self.slide_directory, "data.%s" % self.file_type
+            self.slide_directory, "data.zarr"
         )
         self.zarr_store = zarr.DirectoryStore(tile_directory)
-        if self.file_type == "n5":
-            self.zarr_store = zarr.N5Store(tile_directory)
         self.zarr_group = zarr.group(store=self.zarr_store)
         self.zarr_group.attrs['bioformats2raw.layout'] = LAYOUT_VERSION
 
@@ -520,7 +517,7 @@ class WriteTiles(object):
             x_end = x_start + tile_width
             y_end = y_start + tile_height
             try:
-                # N5/Zarr has a single n-dimensional array representation on
+                # Zarr has a single n-dimensional array representation on
                 # disk (not interleaved RGB)
                 pixels = self.make_planar(pixels, tile_width, tile_height)
                 z = self.zarr_group["0/%d" % resolution]

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -485,7 +485,8 @@ class WriteTiles(object):
         self.zarr_store = FSStore(
             self.slide_directory,
             dimension_separator=dimension_separator,
-            normalize_keys=True
+            normalize_keys=True,
+            auto_mkdir=True
         )
         self.zarr_group = zarr.group(store=self.zarr_store)
         self.zarr_group.attrs['bioformats2raw.layout'] = LAYOUT_VERSION

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -25,6 +25,7 @@ from threading import BoundedSemaphore
 
 from PIL import Image
 from kajiki import PackageLoader
+from zarr.storage import FSStore
 
 
 log = logging.getLogger(__name__)
@@ -478,7 +479,13 @@ class WriteTiles(object):
             log.info("wrote %s image" % image_type)
 
     def create_tile_directory(self, series, resolution, width, height):
-        self.zarr_store = zarr.NestedDirectoryStore(self.slide_directory)
+        dimension_separator = '/'
+        if not self.nested:
+            dimension_separator = '.'
+        self.zarr_store = FSStore(
+            dimension_separator=dimension_separator,
+            normalize_keys=True
+        )
         self.zarr_group = zarr.group(store=self.zarr_store)
         self.zarr_group.attrs['bioformats2raw.layout'] = LAYOUT_VERSION
 

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -473,7 +473,7 @@ class WriteTiles(object):
             log.info("wrote %s image" % image_type)
 
     def create_tile_directory(self, series, resolution, width, height):
-        self.zarr_store = zarr.DirectoryStore(self.slide_directory)
+        self.zarr_store = zarr.NestedDirectoryStore(self.slide_directory)
         self.zarr_group = zarr.group(store=self.zarr_store)
         self.zarr_group.attrs['bioformats2raw.layout'] = LAYOUT_VERSION
 

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -30,7 +30,7 @@ from kajiki import PackageLoader
 log = logging.getLogger(__name__)
 
 # version of the Zarr layout
-LAYOUT_VERSION = 1
+LAYOUT_VERSION = 3
 
 
 class MaxQueuePool(object):
@@ -91,7 +91,7 @@ class WriteTiles(object):
         self.slide_directory = output_path
         self.fill_color = fill_color
 
-        os.makedirs(self.slide_directory, exist_ok=True)
+        os.makedirs(os.path.join(self.slide_directory, "OME"), exist_ok=True)
 
         render_context = softwarerendercontext.SoftwareRenderContext()
         render_backend = softwarerenderbackend.SoftwareRenderBackend()
@@ -377,7 +377,7 @@ class WriteTiles(object):
 
     def write_metadata(self):
         '''write metadata to a JSON file'''
-        metadata_file = os.path.join(self.slide_directory, "METADATA.json")
+        metadata_file = os.path.join(self.slide_directory, "OME", "METADATA.json")
 
         with open(metadata_file, "w", encoding="utf-8") as f:
             metadata = self.get_metadata()
@@ -418,7 +418,7 @@ class WriteTiles(object):
         loader = PackageLoader()
         template = loader.import_("isyntax2raw.resources.ome_template")
         xml = template(xml_values).render()
-        ome_xml_file = os.path.join(self.slide_directory, "METADATA.ome.xml")
+        ome_xml_file = os.path.join(self.slide_directory, "OME", "METADATA.ome.xml")
         with open(ome_xml_file, "w", encoding="utf-8") as omexml:
             omexml.write(xml)
 
@@ -473,10 +473,7 @@ class WriteTiles(object):
             log.info("wrote %s image" % image_type)
 
     def create_tile_directory(self, series, resolution, width, height):
-        tile_directory = os.path.join(
-            self.slide_directory, "data.zarr"
-        )
-        self.zarr_store = zarr.DirectoryStore(tile_directory)
+        self.zarr_store = zarr.DirectoryStore(self.slide_directory)
         self.zarr_group = zarr.group(store=self.zarr_store)
         self.zarr_group.attrs['bioformats2raw.layout'] = LAYOUT_VERSION
 

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -377,7 +377,9 @@ class WriteTiles(object):
 
     def write_metadata(self):
         '''write metadata to a JSON file'''
-        metadata_file = os.path.join(self.slide_directory, "OME", "METADATA.json")
+        metadata_file = os.path.join(
+            self.slide_directory, "OME", "METADATA.json"
+        )
 
         with open(metadata_file, "w", encoding="utf-8") as f:
             metadata = self.get_metadata()
@@ -418,7 +420,9 @@ class WriteTiles(object):
         loader = PackageLoader()
         template = loader.import_("isyntax2raw.resources.ome_template")
         xml = template(xml_values).render()
-        ome_xml_file = os.path.join(self.slide_directory, "OME", "METADATA.ome.xml")
+        ome_xml_file = os.path.join(
+            self.slide_directory, "OME", "METADATA.ome.xml"
+        )
         with open(ome_xml_file, "w", encoding="utf-8") as omexml:
             omexml.write(xml)
 

--- a/isyntax2raw/cli/isyntax2raw.py
+++ b/isyntax2raw/cli/isyntax2raw.py
@@ -46,6 +46,10 @@ def cli():
     help="background color for missing tiles (0-255)"
 )
 @click.option(
+    "--nested/--no-nested", show_default=True,
+    help="Whether to use '/' as the chunk path separator"
+)
+@click.option(
     "--debug", is_flag=True,
     help="enable debugging",
 )
@@ -53,7 +57,7 @@ def cli():
 @click.argument("output_path")
 def write_tiles(
     tile_width, tile_height, resolutions, max_workers, batch_size,
-    input_path, output_path, fill_color, debug
+    fill_color, nested, debug, input_path, output_path
 ):
     level = logging.INFO
     if debug:
@@ -65,7 +69,7 @@ def write_tiles(
     )
     with WriteTiles(
         tile_width, tile_height, resolutions, max_workers,
-        batch_size, input_path, output_path, fill_color
+        batch_size, fill_color, nested, input_path, output_path
     ) as wt:
         wt.write_metadata()
         wt.write_label_image()

--- a/isyntax2raw/cli/isyntax2raw.py
+++ b/isyntax2raw/cli/isyntax2raw.py
@@ -46,7 +46,7 @@ def cli():
     help="background color for missing tiles (0-255)"
 )
 @click.option(
-    "--nested/--no-nested", show_default=True,
+    "--nested/--no-nested", default=True, show_default=True,
     help="Whether to use '/' as the chunk path separator"
 )
 @click.option(

--- a/isyntax2raw/cli/isyntax2raw.py
+++ b/isyntax2raw/cli/isyntax2raw.py
@@ -32,11 +32,6 @@ def cli():
     help="number of pyramid resolutions to generate [default: all]"
 )
 @click.option(
-    "--file_type", type=click.Choice(['n5', 'zarr']), default="n5",
-    show_default=True,
-    help="tile file extension"
-)
-@click.option(
     "--max_workers", default=4, type=int,
     show_default=True,
     help="maximum number of tile workers that will run at one time",
@@ -57,7 +52,7 @@ def cli():
 @click.argument("input_path")
 @click.argument("output_path")
 def write_tiles(
-    tile_width, tile_height, resolutions, file_type, max_workers, batch_size,
+    tile_width, tile_height, resolutions, max_workers, batch_size,
     input_path, output_path, fill_color, debug
 ):
     level = logging.INFO
@@ -69,7 +64,7 @@ def write_tiles(
                "(%(thread)10s) %(message)s"
     )
     with WriteTiles(
-        tile_width, tile_height, resolutions, file_type, max_workers,
+        tile_width, tile_height, resolutions, max_workers,
         batch_size, input_path, output_path, fill_color
     ) as wt:
         wt.write_metadata()

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(name='isyntax2raw',
           'click==7.0',
           'pillow>=7.1.0',
           'numpy==1.17.3',
-          'zarr==2.4.0',
+          'zarr==2.8.1',
           'kajiki==0.8.2',
       ],
       tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(name='isyntax2raw',
           'numpy==1.17.3',
           'zarr==2.8.1',
           'kajiki==0.8.2',
+          'fsspec>=0.9.0',
       ],
       tests_require=[
           'flake8',

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ def read(fname):
 
 setup(name='isyntax2raw',
       version=version.getVersion(),
+      python_requires='>=3.6',
       description='iSyntax to raw format converter',
       long_description=read('README.md'),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
In line with upstream bioformats2raw and raw2ometiff, switch to a Zarr only layout.