### PR TITLE
Update multiscales metadata for OME-NGFF v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Output tile width and height can optionally be specified; default values are
 detailed in `--help`.
 
 A directory structure containing the pyramid tiles at all resolutions and
-macro/label images will be created.  The default format is Zarr.  Additional
-metadata is written to a JSON file.  Be mindful of available disk space, as
+macro/label images will be created.  The default format is Zarr compliant with https://ngff.openmicroscopy.org/0.4.
+Additional metadata is written to a JSON file.  Be mindful of available disk space, as
 larger .isyntax files can result in >20 GB of tiles.
 
 Use of the Zarr file type will result in losslessly compressed output.  This

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -389,13 +389,44 @@ class WriteTiles(object):
             return self.pixel_engine.wait_any(regions)
 
     def write_image_metadata(self, resolutions, series):
+        # OK to hard-code axes; this matches DimensionOrder in ome_template.xml
+        axes = {
+          't': 'time',
+          'c': 'channel',
+          'z': 'space',
+          'y': 'space',
+          'x': 'space'
+        }
+        multiscale_axes = [{'name': x, 'type': axes[x]} for x in axes]
+        if series == 0:
+            for axis in multiscale_axes:
+                if axis['name'] == 'x' or axis['name'] == 'y':
+                    axis['unit'] = 'micrometer'
+
+        metadata = self.get_image_metadata(0)
+        scale_level = [
+          metadata['Level sizes #0']['X'] / metadata['Level sizes #%s' % v]['X']
+          for v in resolutions]
+
+        pixel_size_x = self.pixel_size_x if series == 0 else 1.0
+        pixel_size_y = self.pixel_size_y if series == 0 else 1.0
+
         multiscales = [{
             'metadata': {
                 'method': 'pixelengine',
                 'version': str(self.pixel_engine.version)
             },
-            'version': '0.2',
-            'datasets': [{'path': str(v)} for v in resolutions]
+            'axes': multiscale_axes,
+            'version': '0.4',
+            'datasets': [{
+                'path': str(v),
+                'coordinateTransformations' : [ {
+                    'scale' : [ 1.0, 1.0, 1.0,
+                        pixel_size_y * scale_level[v],
+                        pixel_size_x * scale_level[v]],
+                    'type' : 'scale'
+                }]
+            } for v in resolutions]
         }]
         z = self.zarr_group["%d" % series]
         z.attrs['multiscales'] = multiscales


### PR DESCRIPTION
Compare the results of `isyntax2raw write_tiles input.isyntax output.zarr` with this PR against `bioformats2raw input-file output.zarr` with https://github.com/glencoesoftware/bioformats2raw/releases/tag/v0.5.0rc2 (using any brightfield slide as input, e.g. `CMU-1.svs`).

The `output.zarr/*/.zattrs` files should have similar contents in both sets of output. In particular, check the new `axes` and `coordinateTransformations` to make sure that the order is correct (should be the Zarr storage order, i.e. reverse of the OME-XML `DimensionOrder`). Physical pixel sizes should be included for the slide image itself, but double-check that the sizes scale appropriately for each smaller resolution. Physical sizes should *not* be present for the macro/label images.

All of the `multiscales` dictionaries should now be compliant with https://ngff.openmicroscopy.org/0.4/index.html#multiscale-md.