### PR TITLE
Attempt to handle ISO 8601 dates

### DIFF
--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -19,6 +19,8 @@ import softwarerendercontext
 import softwarerenderbackend
 import zarr
 
+from dateutil.parser import parse
+
 from datetime import datetime
 from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
 from threading import BoundedSemaphore
@@ -327,13 +329,13 @@ class WriteTiles(object):
             timestamp = pe_in.acquisition_datetime.strip()
         # older files store the date time in YYYYmmddHHMMSS.ffffff format
         # newer files use ISO 8601, i.e. YYYY-mm-ddTHH:mm:ss
+        # other timestamp formats may be used in the future
         try:
+            # Handle "special" isyntax date/time format
             return datetime.strptime(timestamp, "%Y%m%d%H%M%S.%f")
-        except Exception:
-            try:
-                return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
-            except Exception:
-                return datetime.min
+        except ValueError:
+            # Handle other date/time formats (such as ISO 8601)
+            return parse(timestamp)
 
     def barcode(self):
         pe_in = self.pixel_engine["in"]

--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -322,10 +322,18 @@ class WriteTiles(object):
     def acquisition_datetime(self):
         pe_in = self.pixel_engine["in"]
         if self.sdk_v1:
-            timestamp = str(pe_in.DICOM_ACQUISITION_DATETIME)
+            timestamp = str(pe_in.DICOM_ACQUISITION_DATETIME).strip()
         else:
-            timestamp = pe_in.acquisition_datetime
-        return datetime.strptime(timestamp, "%Y%m%d%H%M%S.%f")
+            timestamp = pe_in.acquisition_datetime.strip()
+        # older files store the date time in YYYYmmddHHMMSS.ffffff format
+        # newer files use ISO 8601, i.e. YYYY-mm-ddTHH:mm:ss
+        try:
+            return datetime.strptime(timestamp, "%Y%m%d%H%M%S.%f")
+        except Exception:
+            try:
+                return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S")
+            except Exception:
+                return datetime.min
 
     def barcode(self):
         pe_in = self.pixel_engine["in"]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(name='isyntax2raw',
           'zarr==2.8.1',
           'kajiki==0.8.2',
           'fsspec>=0.9.0',
+          'python-dateutil>=2.8.2'
       ],
       tests_require=[
           'flake8',


### PR DESCRIPTION
`1-artificial-iso-timestamp.isyntax` (in same location as `1.isyntax`) is a modified version of `1.isyntax` with the stored timestamp set to `2022-10-01T14:29:21  `; there are 2 trailing spaces to preserve the byte count, as changing the size of overall XML will prevent the file from being read at all. That's probably the best we can do without a real file that demonstrates the new timestamp format.

Without this PR, I'd expect that `isyntax2raw write_tiles 1-artificial-iso-timestamp.isyntax test.zarr` throws a `ValueError`. With this PR, I'd expect the conversion to succeed. The `AcquisitionDate` in `test.zarr/OME/METADATA.ome.xml` should be checked as well.