### PR TITLE
Add case for timestamps with timezone offset

### DIFF
--- a/isyntax2raw/__init__.py
+++ b/isyntax2raw/__init__.py
@@ -327,12 +327,17 @@ class WriteTiles(object):
             timestamp = str(pe_in.DICOM_ACQUISITION_DATETIME).strip()
         else:
             timestamp = pe_in.acquisition_datetime.strip()
-        # older files store the date time in YYYYmmddHHMMSS.ffffff format
+        # older files store the date time in YYYYmmddHHMMSS.ffffff format,
+        # optionally with a timezone offset appended
         # newer files use ISO 8601, i.e. YYYY-mm-ddTHH:mm:ss
         # other timestamp formats may be used in the future
         try:
-            # Handle "special" isyntax date/time format
-            return datetime.strptime(timestamp, "%Y%m%d%H%M%S.%f")
+            try:
+                # Handle "special" isyntax date/time format
+                return datetime.strptime(timestamp, "%Y%m%d%H%M%S.%f")
+            except ValueError:
+                # Handle "special" isyntax date/time format with timezone
+                return datetime.strptime(timestamp, "%Y%m%d%H%M%S.%f%z")
         except ValueError:
             # Handle other date/time formats (such as ISO 8601)
             return parse(timestamp)


### PR DESCRIPTION
This is one approach to fixing #40, but has not yet been tested on real data.

With https://github.com/dateutil/dateutil/issues/1252 still open, the `%Y%m%d%H%M%S.%f%z` format is not handled automatically. Separate cases for `%Y%m%d%H%M%S.%f%z` and `%Y%m%d%H%M%S.%f` appear to be necessary, as if I try a little test like this (using timestamps from #40 and https://github.com/glencoesoftware/isyntax2raw/pull/39#issuecomment-1731789232):

```
>>> new_date = "20241201163630.691045+0000"
>>> old_date = "20190612231659.000000"
>>> time_format = "%Y%m%d%H%M%S.%f%z"
>>> from datetime import datetime
>>> datetime.strptime(new_date, time_format)
datetime.datetime(2024, 12, 1, 16, 36, 30, 691045, tzinfo=datetime.timezone.utc)
>>> datetime.strptime(old_date, time_format)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\melissa\AppData\Local\Programs\Python\Python37\lib\_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "C:\Users\melissa\AppData\Local\Programs\Python\Python37\lib\_strptime.py", line 359, in _strptime
    (data_string, format))
ValueError: time data '20190612231659.000000' does not match format '%Y%m%d%H%M%S.%f%z'
```