### PR TITLE
Fixes GitHub worklows

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,8 +27,8 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -50,8 +50,8 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Build package
         run: |
           # actions/checkout#206

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -22,7 +22,7 @@ jobs:
           - ubuntu-20.04
         include:
           - python-version: '3.7'
-            os: macos-latest
+            os: macos-13
           - python-version: '3.7'
             os: windows-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,7 +19,7 @@ jobs:
           - '3.8'
           - '3.9'
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         include:
           - python-version: '3.7'
             os: macos-13

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -35,9 +38,6 @@ jobs:
         run: python -mpip install -U wheel flake8 virtualenv
       - name: Run tests
         run: |
-            # actions/checkout#206
-            git fetch --prune --unshallow --tags --force
-            git describe
             flake8
             python setup.py build
 
@@ -51,11 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
       - name: Build package
         run: |
-          # actions/checkout#206
-          git fetch --prune --unshallow --tags --force
           python -mpip install wheel
           python setup.py sdist bdist_wheel
       - name: Publish to PyPI


### PR DESCRIPTION
- updates outdated Github actions
- bumps operating systems to supported versions
- removes Python 3.6 from the build matrix entirely

This aims to fix the current build issues by performing the minimal amount of changes. The library should remain compatible with Python 3.6+ although in practice this version is increasingly hard to install.
